### PR TITLE
Support integrations param for track and identify calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ type = :customer_data_request
 SegmentAPI.track(
   SegmentAPI.event(app_slug, type),
   shopify_domain,
-  %{data: %{foo: "bar"}}
+  %{data: %{foo: "bar"}},
+  %{integrations: %{All: true, Salesforce: false}}
 )
 ```


### PR DESCRIPTION
* Adds an `options` map as the last param to the `track` and `identify` functions, to support passing an `integrations` option.